### PR TITLE
Add Woocommerce Submenu Link

### DIFF
--- a/admin/class-xumm-for-woocommerce-admin.php
+++ b/admin/class-xumm-for-woocommerce-admin.php
@@ -397,4 +397,17 @@ class Xumm_For_Woocommerce_Admin
             }
         }
 	}
+
+    /**
+	 * Add submenu link to Woocommerce admin menu
+	 */
+    public function add_woocommerce_menu_link() {
+        add_submenu_page(
+            'woocommerce',
+            __('XUMM', 'woocommerce-xumm'),
+            __('XUMM', 'woocommerce-xumm'),
+            'manage_woocommerce',
+            admin_url('admin.php?page=wc-settings&tab=checkout&section=xumm'),
+            null );
+    }
 }

--- a/includes/class-xumm-for-woocommerce.php
+++ b/includes/class-xumm-for-woocommerce.php
@@ -176,6 +176,8 @@ class Xumm_For_Woocommerce {
         $this->loader->add_action( 'admin_notices', $plugin_admin, 'admin_notices', 12, 1);
         $this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'show_indicator_toolbar', 500, 1);
 
+        $this->loader->add_action( 'admin_menu', $plugin_admin, 'add_woocommerce_menu_link', 55, 1);
+
         $this->loader->add_filter( 'plugin_action_links_xumm-payments-for-woocommerce/xumm-payments-for-woocommerce.php', $plugin_admin, 'settings_link', 10, 1);
 
         $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');


### PR DESCRIPTION
admin_bar_menu link isn't the most intuitive.
Until I found it looking through the code, I've been either going through:
1. Woocommerce -> Settings -> Payments -> Manage XUMM Payments
2. Plugins -> XUMM Settings

Adding the Woocommerce XUMM link I believe might be a bit more user friendly, and is 1-click friendly (for those like myself that were oblivious to the admin_bar_menu link)